### PR TITLE
always cast ctype' is*() argument to unsigned char

### DIFF
--- a/chat.c
+++ b/chat.c
@@ -107,7 +107,8 @@ push_icb_msg_ws(char type, const char *msg, size_t len) {
 					msglen = mbsbreak(src, msglen);
 				else {
 					for (p = src + msglen - 1; p > src; p--)
-						if (isblank(*p) || ispunct(*p)) {
+						if (isblank((unsigned char)*p) ||
+						    ispunct((unsigned char)*p)) {
 							msglen = p - src + 1;
 							break;
 						}
@@ -181,7 +182,7 @@ proceed_user_input(char *line) {
 		return;
 	}
 
-	for (p = line; isspace(*p); p++)
+	for (p = line; isspace((unsigned char)*p); p++)
 		;
 	if (!*p)
 		return;    // add some insult like icb(1) does?

--- a/oicb.c
+++ b/oicb.c
@@ -268,7 +268,7 @@ parse_cmd_line(char *line, struct line_cmd *cmd) {
 	}
 	cmd->start = p++;
 
-	if (!*p || isspace(*p)) {
+	if (!*p || isspace((unsigned char)*p)) {
 		if (debug >= 2)
 			warnx("%s: not a command name, line='%s'",
 			   __func__, line);
@@ -276,7 +276,7 @@ parse_cmd_line(char *line, struct line_cmd *cmd) {
 	}
 	cmd->cmd_name = p;
 
-	while (*p && !isspace(*p))
+	while (*p && !isspace((unsigned char)*p))
 		p++;
 	cmd->cmd_name_end = p;
 	cmd->cmd_name_len = (int)(p - cmd->cmd_name);
@@ -290,7 +290,7 @@ parse_cmd_line(char *line, struct line_cmd *cmd) {
 	    (cmd->cmd_name_len == 3 && memcmp(cmd->cmd_name, "msg", 3) == 0)) {
 		cmd->is_private = 1;
 
-		while (isspace(*p))
+		while (isspace((unsigned char)*p))
 			p++;
 		if (!*p) {
 			cmd->private_prefix_len = (int)(p - line);
@@ -299,13 +299,13 @@ parse_cmd_line(char *line, struct line_cmd *cmd) {
 		cmd->peer_nick = p;
 		cmd->peer_nick_offset = (int)(p - line);
 
-		while (*p && !isspace(*p))
+		while (*p && !isspace((unsigned char)*p))
 			p++;
 		cmd->peer_nick_end = p;
 		cmd->peer_nick_len = (int)(p - cmd->peer_nick);
 		cmd->private_prefix_len = (int)(p - line);
 
-		if (isspace(*p)) {
+		if (isspace((unsigned char)*p)) {
 			cmd->private_msg = ++p;
 			cmd->private_prefix_len++;
 		}


### PR DESCRIPTION
ctype.h `is*()` macros have an issue: on signed char architectures the argument may be sign-extended to an int, mangling the value.  The most idiomatic and safe way to handle it when processing strings is to cast the argument to `unsigned char` to avoid surprises.